### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ![GitHub language count](https://img.shields.io/github/languages/count/kritikos-io/Extensions.Linq)
 ![GitHub top language](https://img.shields.io/github/languages/top/kritikos-io/Extensions.Linq)
 
-Common System.Linq extensions.
+Opinionated System.Linq extensions for common operation, favoring fail fast philosophy.
 
 ## -If type extensions
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ var query = DbContext.EntityName
 
 * OrderByProperty
 * OrderByPropertyDescending
-* OrderByPropertyOrDefault
-* OrderByPropertyOrDefaultDescending
+* ThenByProperty
+* ThenByPropertyDescending
 
 Provides a set of methods allowing ordering a queryable by a property name (passed in as string). Also, an overload accepting a fallback selector is provided, in case the property does not exist on the specified type, or the property string is not populated.
 

--- a/src/Extensions.Linq/OrderedQueryableExtensions.cs
+++ b/src/Extensions.Linq/OrderedQueryableExtensions.cs
@@ -2,10 +2,40 @@ namespace Kritikos.Extensions.Linq
 {
 	using System;
 	using System.Collections.Generic;
+	using System.ComponentModel;
 	using System.Linq;
+	using System.Linq.Expressions;
 
 	public static class OrderedQueryableExtensions
 	{
+		/// <summary>
+		/// Performs a subsequent ordering of the elements in a sequence in ascending order.
+		/// </summary>
+		/// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
+		/// <param name="source">An <see cref="IOrderedQueryable{T}"/> that contains elements to sort.</param>
+		/// <param name="property">The name of the property to use in ordering.</param>
+		/// <returns>An <see cref="IOrderedQueryable{T}"/> whose elements are sorted according to <paramref name="property"/>in ascending order.</returns>
+		/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+		/// <exception cref="ArgumentException"><paramref name="property"/> does not exist on <typeparamref name="TSource"/> or is empty.</exception>
+		public static IOrderedQueryable<TSource> ThenByProperty<TSource>(
+			this IOrderedQueryable<TSource> source,
+			string property)
+			=> source.ThenByPropertyNameInDirection(ListSortDirection.Ascending, property);
+
+		/// <summary>
+		/// Performs a subsequent ordering of the elements in a sequence in descending order.
+		/// </summary>
+		/// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
+		/// <param name="source">An <see cref="IOrderedQueryable{T}"/> that contains elements to sort.</param>
+		/// <param name="property">The name of the property to use in ordering.</param>
+		/// <returns>An <see cref="IOrderedQueryable{T}"/> whose elements are sorted according to <paramref name="property"/>in descending order.</returns>
+		/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+		/// <exception cref="ArgumentException"><paramref name="property"/> does not exist on <typeparamref name="TSource"/> or is empty.</exception>
+		public static IOrderedQueryable<TSource> ThenByPropertyDescending<TSource>(
+			this IOrderedQueryable<TSource> source,
+			string property)
+			=> source.ThenByPropertyNameInDirection(ListSortDirection.Descending, property);
+
 		/// <summary>
 		/// Returns <paramref name="size"/> elements, bypassing those on previous <paramref name="page"/> to facilitate paging.
 		/// </summary>
@@ -34,11 +64,35 @@ namespace Kritikos.Extensions.Linq
 
 			if (size == 0 && page > 1)
 			{
-				throw new ArgumentException("Size 0 should only be used with page number 1, otherwise data parity can not be guaranteed!");
+				throw new ArgumentException(
+					"Size 0 should only be used with page number 1, otherwise data parity can not be guaranteed!");
 			}
 
 			return source.Skip((page - 1) * size)
 				.TakeIf(size > 0, size);
+		}
+
+		private static IOrderedQueryable<TSource> ThenByPropertyNameInDirection<TSource>(
+			this IOrderedQueryable<TSource> source,
+			ListSortDirection direction,
+			string propertyName)
+		{
+			var entity = typeof(TSource);
+			var property = entity.GetProperty(propertyName);
+
+			if (property == null)
+			{
+				throw new ArgumentException($"Type of {entity.FullName} does not contain property {propertyName}!");
+			}
+
+			var arg = Expression.Parameter(entity, "x");
+			var body = Expression.Property(arg, propertyName);
+
+			dynamic selector = Expression.Lambda(body, arg);
+
+			return direction == ListSortDirection.Ascending
+				? Queryable.ThenBy(source, selector)
+				: Queryable.ThenByDescending(source, selector);
 		}
 	}
 }

--- a/src/Extensions.Linq/QueryableOrderingExtensions.cs
+++ b/src/Extensions.Linq/QueryableOrderingExtensions.cs
@@ -20,7 +20,7 @@ namespace Kritikos.Extensions.Linq
 		public static IOrderedQueryable<TSource> OrderByProperty<TSource>(
 			this IQueryable<TSource> source,
 			string property)
-			=> source.OrderByPropertyOrSelector<TSource, int>(property, ListSortDirection.Ascending);
+			=> source.OrderByPropertyNameInDirection(ListSortDirection.Ascending, property);
 
 		/// <summary>
 		/// Sorts the elements of a sequence by <paramref name="property"/> in descending order.
@@ -34,87 +34,23 @@ namespace Kritikos.Extensions.Linq
 		public static IOrderedQueryable<TSource> OrderByPropertyDescending<TSource>(
 			this IQueryable<TSource> source,
 			string property)
-			=> source.OrderByPropertyOrSelector<TSource, int>(property, ListSortDirection.Descending);
-
-		/// <summary>
-		/// Sorts the elements of a sequence by <paramref name="property"/> or a default selector in ascending order.
-		/// </summary>
-		/// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-		/// <typeparam name="TKey">The type of the key returned by <paramref name="selector"/>.</typeparam>
-		/// <param name="source">A sequence of values to order.</param>
-		/// <param name="property">The name of the property to use in ordering. If this is null or does not exist on <typeparamref name="TSource"/>, the <paramref name="selector"/> will be used.</param>
-		/// /// <param name="selector">A function to extract a key from an element.</param>
-		/// <returns>An <see cref="IOrderedQueryable{T}"/> whose elements are sorted according to <paramref name="property"/> or <paramref name="selector"/> in ascending order.</returns>
-		/// <exception cref="ArgumentException"><paramref name="property"/> does not exist on <typeparamref name="TSource"/> or is empty, and <paramref name="selector"/> is <see langword="null"/>.</exception>
-		/// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="selector"/> (when no valid <paramref name="property"/> is provided) is <see langword="null"/>.</exception>
-		public static IOrderedQueryable<TSource> OrderByPropertyOrDefault<TSource, TKey>(
-			this IQueryable<TSource> source,
-			string property,
-			Expression<Func<TSource, TKey>> selector)
-			=> source.OrderByPropertyOrSelector(property, ListSortDirection.Ascending, selector);
-
-		/// <summary>
-		/// Sorts the elements of a sequence by <paramref name="property"/> or a default selector in descending order.
-		/// </summary>
-		/// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-		/// <typeparam name="TKey">The type of the key returned by <paramref name="selector"/>.</typeparam>
-		/// <param name="source">A sequence of values to order.</param>
-		/// <param name="property">The name of the property to use in ordering. If this is null or does not exist on <typeparamref name="TSource"/>, the <paramref name="selector"/> will be used.</param>
-		/// /// <param name="selector">A function to extract a key from an element.</param>
-		/// <returns>An <see cref="IOrderedQueryable{T}"/> whose elements are sorted according to <paramref name="property"/> or <paramref name="selector"/> in descending order.</returns>
-		/// <exception cref="ArgumentException"><paramref name="property"/> does not exist on <typeparamref name="TSource"/> or is empty, and <paramref name="selector"/> is <see langword="null"/>.</exception>
-		/// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="selector"/> (when no valid <paramref name="property"/> is provided) is <see langword="null"/>.</exception>
-		public static IOrderedQueryable<TSource> OrderByPropertyOrDefaultDescending<TSource, TKey>(
-			this IQueryable<TSource> source,
-			string property,
-			Expression<Func<TSource, TKey>> selector)
-			=> source.OrderByPropertyOrSelector(property, ListSortDirection.Descending, selector);
-
-		/// <summary>
-		/// Sorts the elements of a sequence in the order specified by <paramref name="direction"/>.
-		/// </summary>
-		/// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-		/// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
-		/// <param name="source">A sequence of values to order.</param>
-		/// <param name="direction">The direction to sort to.</param>
-		/// <param name="keySelector">A function to extract a key from an element.</param>
-		/// <returns>An <see cref="IOrderedQueryable{T}"/> whose elements are sorted according to a key, in <paramref name="direction"/> order.</returns>
-		/// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="keySelector"/> is <see langword="null"/>.</exception>
-		public static IOrderedQueryable<TSource> OrderByDirection<TSource, TKey>(
-			this IQueryable<TSource> source,
-			ListSortDirection direction,
-			Expression<Func<TSource, TKey>> keySelector)
-			=> direction == ListSortDirection.Ascending
-				? source.OrderBy(keySelector)
-				: source.OrderByDescending(keySelector);
-
-		private static IOrderedQueryable<TSource> OrderByPropertyOrSelector<TSource, TKey>(
-			this IQueryable<TSource> source,
-			string propertyName,
-			ListSortDirection direction,
-			Expression<Func<TSource, TKey>>? keySelector = null)
-		{
-			var entity = typeof(TSource);
-			var property = entity.GetProperty(propertyName);
-
-			if (property == null && keySelector == null)
-			{
-				throw new ArgumentException($"Type of {entity.FullName} does not contain property {propertyName}!");
-			}
-
-			return property != null
-				? source.OrderByPropertyNameInDirection(direction, entity, property)
-				: source.OrderByDirection(direction, keySelector);
-		}
+			=> source.OrderByPropertyNameInDirection(ListSortDirection.Descending, property);
 
 		private static IOrderedQueryable<TSource> OrderByPropertyNameInDirection<TSource>(
 			this IQueryable<TSource> source,
 			ListSortDirection direction,
-			Type type,
-			MemberInfo member)
+			string propertyName)
 		{
-			var arg = Expression.Parameter(type, "x");
-			var body = Expression.Property(arg, member.Name);
+			var entity = typeof(TSource);
+			var property = entity.GetProperty(propertyName);
+
+			if (property == null)
+			{
+				throw new ArgumentException($"Type of {entity.FullName} does not contain property {propertyName}!");
+			}
+
+			var arg = Expression.Parameter(entity, "x");
+			var body = Expression.Property(arg, propertyName);
 
 			dynamic selector = Expression.Lambda(body, arg);
 

--- a/tests/Extensions.LinqTests/OrderedQueryableTests.cs
+++ b/tests/Extensions.LinqTests/OrderedQueryableTests.cs
@@ -43,5 +43,24 @@ namespace Kritikos.Extensions.LinqTests
 			page = arr.Slice(1, 0).ToList();
 			Assert.Equal(arrSize, page.Count);
 		}
+
+		[Fact]
+		public void ThenByTests()
+		{
+			var animals = QueryableOrderingTests.Animals.OrderByProperty("Id");
+
+			Assert.Throws<ArgumentException>(() => animals.ThenByProperty("Ib"));
+			Assert.Throws<ArgumentException>(() => animals.ThenByPropertyDescending("Ib"));
+
+			var withSelector = animals.ThenBy(x => x.Name);
+			var withProperty = animals.ThenByProperty("Name");
+
+			Assert.Equal(withSelector,withProperty);
+
+			var withSelectorDesc = animals.ThenBy(x => x.Name);
+			var withPropertyDesc = animals.ThenByProperty("Name");
+
+			Assert.Equal(withSelectorDesc, withPropertyDesc);
+		}
 	}
 }

--- a/tests/Extensions.LinqTests/QueryableOrderingTests.cs
+++ b/tests/Extensions.LinqTests/QueryableOrderingTests.cs
@@ -11,7 +11,7 @@ namespace Kritikos.Extensions.LinqTests
 
 	public class QueryableOrderingTests
 	{
-		private static IQueryable<Animal> Animals { get; } = new List<Animal>
+		internal static IQueryable<Animal> Animals { get; } = new List<Animal>
 		{
 			new Animal { Id = 0, Name = "Sir Cat-a-lot" },
 			new Animal { Id = 1, Name = "Bark-a-lot" },
@@ -32,26 +32,6 @@ namespace Kritikos.Extensions.LinqTests
 			Assert.Equal(sortBySelectorDescending,sortByPropertyNameDescending);
 
 			Assert.Throws<ArgumentException>(() => Animals.OrderByPropertyDescending("Is"));
-		}
-
-		[Fact]
-		public void OrderByNameOrDefault()
-		{
-			var sortByPropertyName = Animals.OrderByPropertyOrDefault("Id", x => x.Name);
-			var sortByInvalidProperty = Animals.OrderByPropertyOrDefault("ib", x => x.Name);
-			var orderByName = Animals.OrderBy(x => x.Name);
-			var orderById = Animals.OrderBy(x => x.Id);
-
-			Assert.Equal(orderById,sortByPropertyName);
-			Assert.Equal(orderByName,sortByInvalidProperty);
-
-			var sortByPropertyNameDesc = Animals.OrderByPropertyOrDefaultDescending("Id", x => x.Name);
-			var sortByInvalidPropertyNameDesc = Animals.OrderByPropertyOrDefaultDescending("Ib", x => x.Name);
-			var orderByNameDesc = Animals.OrderByDescending(x => x.Name);
-			var orderByIdDesc = Animals.OrderByDescending(x => x.Id);
-
-			Assert.Equal(orderByIdDesc,sortByPropertyNameDesc);
-			Assert.Equal(orderByNameDesc,sortByInvalidPropertyNameDesc);
 		}
 	}
 }


### PR DESCRIPTION
# Changelog

Removes Default selector methods in ordering, in favor of fail fast pivoting.
Adds ThenBy to chain ordering expressions